### PR TITLE
Textures shouldn't be premultiplied

### DIFF
--- a/kpspemu/common/src/main/kotlin/com/soywiz/kpspemu/AGRenderer.kt
+++ b/kpspemu/common/src/main/kotlin/com/soywiz/kpspemu/AGRenderer.kt
@@ -239,7 +239,7 @@ class AGRenderer(val emulatorContainer: WithEmulator, val sceneTex: Texture) : W
 			val textureId = batch.getTextureId()
 
 			textureSlot = texturesById.getOrPut(textureId) {
-				TextureSlot(textureId, ag.createTexture())
+				TextureSlot(textureId, ag.createTexture(premultiplied = false))
 			}
 
 			if (textureSlot.frame != frameCount) {


### PR DESCRIPTION
This fixes SDL games that uses textures ignoring alpha