### PR TITLE
Kotlin 1.2.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ext.korgeVersion = "0.19.2"
     ext.korimVersion = "0.19.1"
     ext.koruiVersion = "0.19.2"
-    ext.kotlinVersion = '1.2.10'
+    ext.kotlinVersion = '1.2.21'
 
     repositories {
         jcenter()

--- a/kpspemu/common/src/main/kotlin/com/soywiz/kpspemu/hle/modules/sceGe_user.kt
+++ b/kpspemu/common/src/main/kotlin/com/soywiz/kpspemu/hle/modules/sceGe_user.kt
@@ -62,6 +62,7 @@ class sceGe_user(emulator: Emulator) : SceModule(emulator, "sceGe_user", 0x40010
 			PspGeSyncType.PSP_GE_LIST_DONE, PspGeSyncType.PSP_GE_LIST_DRAWING_DONE -> {
 				emulator.gpuRenderer.queuedJobs.waitValue(0)
 			}
+			else -> Unit // @TODO: @BUG in JS: See https://youtrack.jetbrains.com/issue/KT-22544
 		}
 		//display.waitVblank()
 		return 0

--- a/kpspemu/common/src/test/kotlin/com/soywiz/kpspemu/generate/TableGeneratorScriptTest.kt
+++ b/kpspemu/common/src/test/kotlin/com/soywiz/kpspemu/generate/TableGeneratorScriptTest.kt
@@ -90,7 +90,7 @@ class TableGenerator {
     private fun _createSwitch(writer: Indenter, instructions: List<InstructionType>, baseMask: Int = 0xFFFFFFFF.toInt(), level: Int = 0) {
         if (level >= 10) throw Exception("ERROR: Recursive detection")
         val commonMask = this.getCommonMask(instructions, baseMask)
-        val groups: HashMap<Int, ArrayList<InstructionType>> = LinkedHashMap()
+        val groups = LinkedHashMap<Int, ArrayList<InstructionType>>()
         for (item in instructions) {
             val commonValue = item.vm.value and commonMask
             val group = groups.getOrPut(commonValue) { arrayListOf() }


### PR DESCRIPTION
Check if it reproduces this bug:

```
e: kotlin.KotlinNullPointerException
        at org.jetbrains.kotlin.js.inline.util.CollectUtilsKt$collectBreakContinueTargets$1.visitBreak(collectUtils.kt:291)
        at org.jetbrains.kotlin.js.backend.ast.JsBreak.accept(JsBreak.java:24)
        at org.jetbrains.kotlin.js.backend.ast.JsVisitor.accept(JsVisitor.kt:11)
        at org.jetbrains.kotlin.js.backend.ast.JsVisitor.acceptWithInsertRemove(JsVisitor.kt:26)
        at org.jetbrains.kotlin.js.backend.ast.JsBlock.acceptChildren(JsBlock.java:57)
        at org.jetbrains.kotlin.js.backend.ast.RecursiveJsVisitor.visitElement(RecursiveJsVisitor.java:24)
        at org.jetbrains.kotlin.js.backend.ast.JsVisitor.visitBlock(JsVisitor.kt:40)
        at org.jetbrains.kotlin.js.backend.ast.JsBlock.accept(JsBlock.java:52)
        at org.jetbrains.kotlin.js.inline.util.CollectUtilsKt.collectBreakContinueTargets(collectUtils.kt:243)
        at org.jetbrains.kotlin.js.coroutine.CoroutineBodyTransformer.preProcess(CoroutineBodyTransformer.kt:50)
        at org.jetbrains.kotlin.js.coroutine.CoroutineFunctionTransformer.transform(CoroutineFunctionTransformer.kt:48)
        at org.jetbrains.kotlin.js.coroutine.CoroutineTransformer.visit(CoroutineTransformer.kt:49)
        at org.jetbrains.kotlin.js.backend.ast.JsExpressionStatement.traverse(JsExpressionStatement.java:49)
        at org.jetbrains.kotlin.js.backend.ast.JsVisitorWithContextImpl.doTraverse(JsVisitorWithContextImpl.java:187)
        at org.jetbrains.kotlin.js.backend.ast.JsVisitorWithContextImpl$ListContext.traverse(JsVisitorWithContextImpl.java:88)
        at org.jetbrains.kotlin.js.backend.ast.JsVisitorWithContextImpl.doAcceptStatementList(JsVisitorWithContextImpl.java:171)
        at org.jetbrains.kotlin.js.backend.ast.JsVisitorWithContext.acceptStatementList(JsVisitorWithContext.java:59)
        at org.jetbrains.kotlin.js.backend.ast.JsBlock.traverse(JsBlock.java:63)
        at org.jetbrains.kotlin.js.backend.ast.JsVisitorWithContextImpl.doTraverse(JsVisitorWithContextImpl.java:187)
        at org.jetbrains.kotlin.js.backend.ast.JsVisitorWithContextImpl$NodeContext.traverse(JsVisitorWithContextImpl.java:136)
        at org.jetbrains.kotlin.js.backend.ast.JsVisitorWithContextImpl.doAccept(JsVisitorWithContextImpl.java:147)
        at org.jetbrains.kotlin.js.backend.ast.JsVisitorWithContext.accept(JsVisitorWithContext.java:38)
        at org.jetbrains.kotlin.js.facade.K2JSTranslator.translateUnits(K2JSTranslator.java:149)
        at org.jetbrains.kotlin.js.facade.K2JSTranslator.translate(K2JSTranslator.java:96)
        at org.jetbrains.kotlin.cli.js.K2JSCompiler.translate(K2JSCompiler.java:149)
        at org.jetbrains.kotlin.cli.js.K2JSCompiler.doExecute(K2JSCompiler.java:275)
        at org.jetbrains.kotlin.cli.js.K2JSCompiler.doExecute(K2JSCompiler.java:82)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.java:109)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.java:53)
        at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:92)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl$compile$1$2.invoke(CompileServiceImpl.kt:387)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl$compile$1$2.invoke(CompileServiceImpl.kt:97)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl$doCompile$$inlined$ifAlive$lambda$2.invoke(CompileServiceImpl.kt:895)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl$doCompile$$inlined$ifAlive$lambda$2.invoke(CompileServiceImpl.kt:97)
        at org.jetbrains.kotlin.daemon.common.DummyProfiler.withMeasure(PerfUtils.kt:137)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl.checkedCompile(CompileServiceImpl.kt:925)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl.doCompile(CompileServiceImpl.kt:894)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:386)
        at sun.reflect.GeneratedMethodAccessor84.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:357)
        at sun.rmi.transport.Transport$1.run(Transport.java:200)
        at sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.security.AccessController.doPrivileged(Native Method)
        at sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:568)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:826)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:683)
        at java.security.AccessController.doPrivileged(Native Method)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:682)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```